### PR TITLE
4-2　従業員詳細ページの給料にて３桁ごとのカンマを表示

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -168,7 +168,7 @@
                   <tr>
                     <th nowrap>給料</th>
                     <td>
-                      <span th:utext="${employee.salary + '円'}">400000円</span>
+                      <span th:utext="${#numbers.formatInteger(employee.salary,1,'COMMA') + '円'}">400000円</span>
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
4-2　従業員詳細ページの給料にて３桁ごとのカンマを表示しました。
レビューお願いします。